### PR TITLE
Remove "ammobox_board" entry for now

### DIFF
--- a/configs/backpack2.cfg
+++ b/configs/backpack2.cfg
@@ -457,15 +457,18 @@
 			"columns" "right"
 		}
 
-		"ammobox_board"
-		{
-			"id" "61"
-			"ammo-id" "14"
-			"model"		"models/weapons/tool_barricade/w_barricadeboard.mdl"
-			"capacity"		"1"
-			"loot"	"no"
-			"columns" "right"
-		}
+		// HACKHACK: Prevent boards from being packed because of a native code bug eating them.
+		// This issue is client-side and can't be fixed in the plugin, wait for a game update! 
+		// See https://github.com/nmrih/source-game/issues/1256
+//		"ammobox_board"
+//		{
+//			"id" "61"
+//			"ammo-id" "14"
+//			"model"		"models/weapons/tool_barricade/w_barricadeboard.mdl"
+//			"capacity"		"1"
+//			"loot"	"no"
+//			"columns" "right"
+//		}
 
 		"ammobox_flare"
 		{


### PR DESCRIPTION
Prevent boards from being packed because of a native code bug eating them.

This issue is client-side and can't be fixed in the plugin.

See https://github.com/nmrih/source-game/issues/1256